### PR TITLE
Bug Fix: substitute spaces by dashes regex to support relative path

### DIFF
--- a/plugin/wikilink.vim
+++ b/plugin/wikilink.vim
@@ -82,7 +82,7 @@ function! WikiLinkGetWord()
     endif
 
     "substitute spaces by dashes
-    let word = substitute(word, '[ /]', '-', 'g')
+    let word = substitute(word, '[ ]', '-', 'g')
   end
 
   return word


### PR DESCRIPTION
The previous `let word = substitute(word, '[ /]', '-', 'g')` command was
undesirably modifying relative links to have a '-' as the path
delimiter. For example 
[[Link description|path/to/link.markdown]] 
was being changed to 
[[Link description|path-to-link.markdown]] 
the substitute command now respects nested file paths.
