### PR TITLE
only end a new filename with a "." if current filename ends with one

### DIFF
--- a/plugin/wikilink.vim
+++ b/plugin/wikilink.vim
@@ -104,7 +104,15 @@ function! WikiLinkWordFilename(word)
       endif
     endif
     let extension = fnamemodify(cur_file_name, ":e")
-    let file_name = dir.a:word.".".extension
+    if !empty(extension)
+      let file_name = dir.a:word.".".extension
+    else
+      if (match(fnamemodify(cur_file_name, ":t"), '\.') != -1)
+        let  file_name = dir.a:word."."
+      else
+        let file_name = dir.a:word
+      endif
+    endif
   endif
   return file_name
 endfunction


### PR DESCRIPTION
I noticed that if the current file was "main" and I selected the wiki link "[[notes]]" the new file was caled "notes.". Now the new file will only end in a "." if the current file also ends with one. Otherwise the new file will have an extension matching the current file or it will have not ".".

Examples:
"main" results in "notes"
"main." results in "notes."
"main.md" results in "notes.md"